### PR TITLE
feat: add new event for saving form with control + s keys

### DIFF
--- a/client/src/modules/shared/components/form/form.component.html
+++ b/client/src/modules/shared/components/form/form.component.html
@@ -1,4 +1,4 @@
-<div class="form-container">
+<div class="form-container" (keydown.control.s)="save(true, $event)">
   <ul class="toolbar cf">
     <li (click)="save()">
       <a><i class="far fa-save"></i></a>

--- a/client/src/modules/shared/components/form/form.component.ts
+++ b/client/src/modules/shared/components/form/form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -10,7 +10,11 @@ export class FormComponent {
   @Input() formGroup!: FormGroup<any>;
   @Output() onSaveClicked = new EventEmitter<any>();
 
-  public save(): void {
+  public save(isKeyDown?: boolean, event?: Event): void {
+    if (isKeyDown) {
+      event?.preventDefault();
+      event?.stopPropagation();
+    }
     this.onSaveClicked.emit();
   }
 }


### PR DESCRIPTION
for this feature, i use from (keydown.control.s) on form container div and then i prevent showing default window of saving file in browser